### PR TITLE
invoke bins via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "sinon-as-promised": "^4.0.0"
   },
   "scripts": {
-    "start": "./node_modules/.bin/babel-node src/index.js",
-    "build:js": "./node_modules/.bin/browserify public/js -t [babelify] > public/bundle.js",
-    "build:css": "./node_modules/.bin/node-sass --source-map true public/scss/styles.scss > public/bundle.css",
+    "start": "babel-node src/index.js",
+    "build:js": "browserify public/js -t [babelify] > public/bundle.js",
+    "build:css": "node-sass --source-map true public/scss/styles.scss > public/bundle.css",
     "serve": "npm run build:js && npm run build:css && npm start",
     "watch": "nodemon --exec 'npm run serve' -e 'js scss' -w src/ -w public/js -w public/scss",
     "test": "mocha",
-    "coverage": "node_modules/.bin/babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha"
+    "coverage": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
npm prepends $(npm bin) to $PATH automatically before executing npm run-scripts.