### PR TITLE
code: fix webhooks to work in a better way

### DIFF
--- a/src/helpers/addWebhooksForLink.js
+++ b/src/helpers/addWebhooksForLink.js
@@ -7,6 +7,31 @@ export function getBackstrokeUrlFor(link) {
   return `${hostname}/_${link._id}`;
 }
 
+function addWebhookToRepo(gh, config, user, owner, repo) {
+  console.log(owner, repo);
+  return gh.reposCreateHook({
+    owner,
+    repo,
+    config,
+    name: 'web',
+    events: ['push'],
+  }).catch(err => {
+    if (err.code === 422) { // The webhook already exists
+      return false;
+    } else if (err.code === 404) { // No permission to add a webhook to this repo
+      return {
+        error: [
+          `No permission to add a webhook to the repository ${owner}/${repo}.`,
+          `Make sure ${user.user} has given Backstroke permission to access this organisation or`,
+          `repo via OAuth.`,
+        ].join(' '),
+      };
+    } else {
+      return Promise.reject(err);
+    }
+  });
+}
+
 // Given a link, try to add a webhook within the parent repository.
 export function addWebhooksForLink(user, link) {
   let gh = createGithubInstance(user);
@@ -15,32 +40,27 @@ export function addWebhooksForLink(user, link) {
     content_type: 'json',
   };
 
+  let operations = [];
+
   if (link.from.type === 'repo') {
     let [fromUser, fromRepo] = getRepoName(link.from);
-    return gh.reposCreateHook({
-      owner: fromUser,
-      repo: fromRepo,
-      config,
-      name: 'web',
-      events: ['push'],
-    }).catch(err => {
-      if (err.code === 422) { // The webhook already exists
-        return false;
-      } else if (err.code === 404) { // No permission to add a webhook
-        return {
-          error: [
-            `No permission to add a webhook to the repository ${fromUser}/${fromRepo}.`,
-            `Make sure ${user.user} has given Backstroke permission to access this organisation or`,
-            `repo via OAuth.`,
-          ].join(' '),
-        };
-      } else {
-        return Promise.reject(err);
-      }
-    });
-  } else {
-    return Promise.resolve(true); // no webhook to add
+    operations.push(addWebhookToRepo(gh, config, user, fromUser, fromRepo));
   }
+  if (link.to.type === 'repo') {
+    let [toUser, toRepo] = getRepoName(link.to);
+    operations.push(addWebhookToRepo(gh, config, user, toUser, toRepo));
+  }
+
+  return Promise.all(operations).then(results => {
+    let errors = results.filter(r => r && r.error);
+
+    // If at least one webhook was successfullt added, then succeed.
+    if (errors.length === 0 || results.length - errors.length > 0) {
+      return Promise.resolve(true); // no webhook to add
+    } else {
+      return Promise.reject(errors[0]);
+    }
+  });
 }
 
 export function removeOldWebhooksForLink(user, link) {
@@ -58,7 +78,7 @@ export function removeOldWebhooksForLink(user, link) {
       } else {
         throw err; // rethrow error
       }
-    })
+    });
   } else {
     return Promise.resolve(true); // no webhook to remove
   }


### PR DESCRIPTION
Prior, webhooks would only be added to the `to` repo in a link, and would fail otherwise. Now,
webhooks will be added to either the `to` repo or the `from` repo (or both). As long as one of the
adds succeeds the whole operation is successful.