### PR TITLE
LICENCE.md: format title

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,4 +1,5 @@
-ISC License (ISC)
+## ISC License (ISC)
+
 Copyright (c) 2016, Ryan Gaus <rsg1egoman@gmail.com>
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
In markdown, a single line break is ignored. This change adds a blank line between the title and the copyright notice, so they are rendered as two lines both in the source and in the rendered views, and also formats the title with the appropriate semantic markup (a markdown heading).